### PR TITLE
fix: 히어로 배너 상단 잘림 수정

### DIFF
--- a/src/components/hero-banner.tsx
+++ b/src/components/hero-banner.tsx
@@ -179,12 +179,12 @@ export function HeroBanner() {
   const PrimaryIcon = slide.primaryLink.icon;
 
   return (
-    <section className="relative overflow-hidden rounded-2xl">
+    <section className="relative overflow-x-clip rounded-2xl">
       {/* 슬라이드 */}
       <div
         key={current}
         className={cn(
-          "relative flex min-h-[360px] items-center justify-center bg-gradient-to-br px-6 pb-14 text-center sm:min-h-[400px] sm:px-12",
+          "relative flex min-h-[420px] items-center justify-center bg-gradient-to-br px-6 pt-10 pb-16 text-center sm:min-h-[460px] sm:px-12",
           slide.bg,
           "animate-in fade-in duration-500",
           direction === "right" ? "slide-in-from-right-8" : "slide-in-from-left-8",


### PR DESCRIPTION
## Summary
- 히어로 배너 `overflow-hidden` → `overflow-x-clip` 변경으로 상단 콘텐츠 잘림 해결
- 슬라이드 수평 전환 클리핑은 유지하면서 수직 방향은 visible 처리
- 상하 패딩(`pt-10 pb-16`) 및 `min-height` 조정으로 충분한 여백 확보

## Test plan
- [ ] 메인 페이지에서 히어로 배너 상단이 잘리지 않는지 확인
- [ ] 슬라이드 좌우 전환 애니메이션이 정상 동작하는지 확인
- [ ] 아이콘 bounce 애니메이션이 잘리지 않는지 확인
- [ ] 모바일/데스크톱 반응형 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)