### PR TITLE
fix: Supabase Auth lazy 호출로 504 해결 및 카테고리 개수 APPROVED 필터 추가

### DIFF
--- a/docs/requirements/2026-03-26-fix-504-category-count.md
+++ b/docs/requirements/2026-03-26-fix-504-category-count.md
@@ -1,0 +1,32 @@
+# fix: 504 타임아웃 및 카테고리 개수 불일치 수정
+
+## 배경
+
+1. **504 Gateway Timeout**: 모든 라우트(`/`, `/tips`, `/category/*`, `/api/trpc/*`)에서 25초 타임아웃 발생
+2. **카테고리 개수 불일치**: 카테고리 뱃지의 팁 개수가 실제 공개된 팁 수와 다름
+
+## 근본 원인 분석
+
+### 504 타임아웃
+- `src/server/api/trpc.ts:12`에서 `await supabase.auth.getUser()`를 context 생성 시 **eagerly** 호출
+- `publicProcedure`(인증 불필요)에서도 매번 Supabase Auth API를 호출
+- Supabase Auth 서비스가 Unhealthy/느릴 때 모든 요청이 블로킹됨
+
+### 카테고리 개수 불일치
+- `src/server/api/routers/category.ts:32`에서 `_count: { select: { tips: true } }`가 모든 상태의 팁을 카운트
+- PENDING, REJECTED 상태의 팁도 포함되어 실제 사용자에게 보이는 수와 다름
+
+## 수정 방안
+
+### 1. `supabase.auth.getUser()` lazy 호출로 변경
+- `createTRPCContext`에서 `supabaseUser`를 즉시 조회하지 않고 lazy getter로 변경
+- `protectedProcedure`에서만 실제로 호출되도록 변경
+- publicProcedure는 Supabase Auth 호출 없이 즉시 응답 가능
+
+### 2. 카테고리 팁 개수에 APPROVED 필터 추가
+- `getAll`, `getTopCategories` 쿼리의 `_count`에 `where: { status: "APPROVED" }` 조건 추가
+
+## 영향 범위
+
+- `src/server/api/trpc.ts` — context 생성 로직
+- `src/server/api/routers/category.ts` — 카테고리 쿼리

--- a/docs/reviews/2026-03-26-fix-504-category-count.md
+++ b/docs/reviews/2026-03-26-fix-504-category-count.md
@@ -1,0 +1,26 @@
+# Review: 504 타임아웃 및 카테고리 개수 불일치 수정
+
+## 구현 내용
+
+### 1. Supabase Auth lazy 호출 (504 수정)
+- `createTRPCContext`에서 `supabase.auth.getUser()`를 eager → lazy로 변경
+- `getSupabaseUser()` lazy getter 도입: 실제로 인증이 필요한 `protectedProcedure`에서만 호출
+- `publicProcedure`는 Supabase Auth API 호출 없이 즉시 응답 가능
+- context에서 `supabaseUser` 프로퍼티 제거 (외부에서 직접 참조하는 곳 없음 확인)
+
+### 2. 카테고리 팁 개수 APPROVED 필터 추가
+- `getAll`, `getTopCategories` 쿼리의 `_count`에 `where: { status: "APPROVED" }` 조건 추가
+- PENDING/REJECTED 상태의 팁이 카운트에서 제외됨
+
+## 주요 결정
+- `supabaseUser`를 context에서 완전히 제거하고 `getUser()` 내부에서만 참조하도록 캡슐화
+- 두 lazy getter 모두 캐싱 적용 (동일 요청 내 중복 호출 방지)
+
+## 변경 파일
+- `src/server/api/trpc.ts` — context 생성에서 auth lazy 호출
+- `src/server/api/routers/category.ts` — 카테고리 개수 APPROVED 필터
+- `docs/requirements/2026-03-26-fix-504-category-count.md` — 요구사항 문서
+- `docs/reviews/2026-03-26-fix-504-category-count.md` — 리뷰 문서
+
+## 알려진 제한사항
+- Supabase Auth 자체가 완전히 다운되면 `protectedProcedure`는 여전히 영향받음 (이는 의도된 동작)

--- a/src/server/api/routers/category.ts
+++ b/src/server/api/routers/category.ts
@@ -6,7 +6,7 @@ export const categoryRouter = createTRPCRouter({
     return ctx.db.category.findMany({
       include: {
         topCategory: true,
-        _count: { select: { tips: true } },
+        _count: { select: { tips: { where: { status: "APPROVED" } } } },
       },
       orderBy: [
         { topCategory: { sortOrder: "asc" } },
@@ -29,7 +29,7 @@ export const categoryRouter = createTRPCRouter({
       include: {
         categories: {
           include: {
-            _count: { select: { tips: true } },
+            _count: { select: { tips: { where: { status: "APPROVED" } } } },
           },
           orderBy: { sortOrder: "asc" },
         },

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -9,24 +9,35 @@ type DbUser = { id: string; nickname: string; email: string; image: string | nul
 
 export const createTRPCContext = async (opts: { headers: Headers }) => {
   const supabase = await createClient();
-  const { data: { user: supabaseUser } } = await supabase.auth.getUser();
+
+  // Lazy auth — Supabase Auth API 호출을 protectedProcedure에서만 수행
+  type SupabaseUser = { id: string; email?: string };
+  let cachedSupabaseUser: SupabaseUser | null | undefined;
+  const getSupabaseUser = async (): Promise<SupabaseUser | null> => {
+    if (cachedSupabaseUser !== undefined) return cachedSupabaseUser;
+    const { data: { user } } = await supabase.auth.getUser();
+    cachedSupabaseUser = user;
+    return user;
+  };
 
   // Lazy user getter — DB 조회는 실제로 호출될 때만 수행
   let cachedUser: DbUser | null | undefined;
   const getUser = async (): Promise<DbUser | null> => {
     if (cachedUser !== undefined) return cachedUser;
+    const supabaseUser = await getSupabaseUser();
     if (!supabaseUser) {
       cachedUser = null;
       return null;
     }
-    cachedUser = await db.user.findUnique({
+    const user = await db.user.findUnique({
       where: { id: supabaseUser.id },
       select: { id: true, nickname: true, email: true, image: true, role: true },
     });
-    return cachedUser;
+    cachedUser = user;
+    return user;
   };
 
-  return { db, supabaseUser, getUser, supabase, ...opts };
+  return { db, getUser, supabase, ...opts };
 };
 
 const t = initTRPC.context<typeof createTRPCContext>().create({


### PR DESCRIPTION
## 변경 사항
- `createTRPCContext`에서 `supabase.auth.getUser()`를 eager → lazy getter로 변경
  - `publicProcedure`가 Supabase Auth 장애/지연에 영향받지 않음
  - 인증이 필요한 `protectedProcedure`에서만 Auth API 호출
- 카테고리 `_count` 쿼리에 `where: { status: "APPROVED" }` 필터 추가
  - PENDING/REJECTED 상태 팁이 뱃지 개수에서 제외됨

## 스크린샷 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)